### PR TITLE
Tweaks:

### DIFF
--- a/test/view/exclusive_scan.cpp
+++ b/test/view/exclusive_scan.cpp
@@ -14,14 +14,15 @@
 #include <range/v3/view/exclusive_scan.hpp>
 #include "../test_utils.hpp"
 
-int main(){
+int main()
+{
     using namespace ranges;
 
     {// For non empty range.
         int rgi[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
         {
-            auto && rng = rgi | view::exclusive_scan(0);
+            auto rng = rgi | view::exclusive_scan(0);
             has_type<int &>(*begin(rgi));
             has_type<int>(*begin(rng));
             models<concepts::SizedView>(aux::copy(rng));
@@ -41,7 +42,7 @@ int main(){
 
     {// For an empty range.
         std::vector<int> rgi;
-        auto && rng = rgi | view::exclusive_scan(0);
+        auto rng = rgi | view::exclusive_scan(0);
         has_type<int>(*begin(rng));
         models<concepts::SizedView>(aux::copy(rng));
         models<concepts::ForwardView>(aux::copy(rng));


### PR DESCRIPTION
* Reorder includes lexicographically

* Store `semiregular_t<T>` in the adaptor just as in the view itself

* Nitpicky formatting changes

* Try to correct the constraints on the function argument: it must be invocable with an rvalue `T` and a reference into the underlying range, and the result must be assignable to a `T &`.

* Consistently default the function argument to `ranges::plus`.
